### PR TITLE
Revised README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Windows         | Open the archive and copy content of the `ffi` folder (`ffi\*`
 
 ## API
 
-`ffi.q` exposes two main functions in `.ffi` namespace. See `test_ffi.q` for detailed examples of usage.
+`ffi.q` exposes two main functions in the `.ffi` namespace. See `test_ffi.q` for detailed examples of usage.
 
 
 ### Passing data and getting back results
@@ -72,15 +72,15 @@ It is possible to pass a q function to C code as a callback (see `qsort` example
 
 Simple function call, intended for one-off calls, and taking two arguments:
 
-1. Function name (symbol) or list of return type char and function name.
+1. Function name (symbol) or list of the return type char and the function name.
 2. Mixed list of arguments. The types of arguments passed to the function are inferred from the q types and should match the width of the arguments the C function expects. (If an argument is not a mixed list, append `(::)` to it.)
 
 
 ### `bind` – create projection with function resolved to call with arguments
 
-Prepares a q function and bind it to the provided C function for future calls. Useful for multiple calls to C lib. Takes three arguments:
+Prepares a q function and binds it to the provided C function for future calls. Useful for multiple calls to C lib. Takes three arguments:
 
-1. function name: simple symbol or list of 2 symbols specifying library name 
+1. function name: simple symbol or list of two symbols specifying library name 
 2. char array of argument types
 3. char with return type
 
@@ -89,12 +89,12 @@ Some utility functions are provided as well:
 
 function | purpose
 ---------|-------------------------------------------------------------------------------------
-`cif`    | prepare argument and return types to be used in `call`
-`call`   | call function using prepared types by `cif` with arguments provided
+`cif`    | prepare the return and argument types to be used in `call`
+`call`   | call the function with the argument/s and the types prepared by `cif`
 `errno`  | return current `errno` global on \*nix OS
-`kfn`    | bind function which returns and accepts K objects in current process. Similar to `2:`
+`kfn`    | bind the function which returns and accepts K objects in current process. Similar to `2:`
 
-Arguments to call with should be passed as a generic list to `cf`, `call` and the function created by `bind`.
+Function arguments should be passed as a generic list to `cf`, `call`, and the function created by `bind`.
 
 `cf` and `call` perform native function loading and resolution at the time of the call, which creates significant overhead. Use `bind` to perform this step in advance and reduce runtime overhead.
 
@@ -162,6 +162,6 @@ r:{b:20#"\000";n:.ffi.cf[`read](x;b;20);0N!n#b;0}
 ```
 
 
-- - - - - - - - -
 ## Notes
-This version is based on original [ffiq](https://github.com/enlnt/ffiq) created by @abalkin
+
+This version is based on an original [ffiq](https://github.com/enlnt/ffiq) created by @abalkin

--- a/README.md
+++ b/README.md
@@ -1,107 +1,106 @@
-# Foreign Function Interface for kdb+
+# Foreign-function interface for kdb+
 
 `ffiq` is an extension to kdb+ for loading and calling dynamic libraries using pure `q`. 
 
-Main purpose of the library is to build stable interfaces on top of external libraries or interact with operating system from `q`. No compiler toolchain or writing C/C++ code should be required when using this library.
+The main purpose of the library is to build stable interfaces on top of external libraries, or to interact with the operating system from `q`. No compiler toolchain or writing C/C++ code is required to use this library.
 
-***DANGER*** Although you don't need to write C code, you do need to know what you are doing. You can easily crash kdb+ process or corrupt in-memory data structures without any hope to find out what has happened. You would not get any support for crashes caused by use of this library.
+**Watch out** You don’t need to write C code, but you do need to know what you are doing. You can easily crash the kdb+ process or corrupt in-memory data structures with no hope of finding out what happened. No support is offered for crashes caused by use of this library.
 
 ## Requirements
- - Linux, macOS 10.10+, Windows 7+
- - libffi 3.1+(see installation instructions below)
- - Latest build of kdb+ 3.4 or higher
 
-### Installation
-#### Dependencies
+### Operating system
+Linux, macOS 10.10+, Windows 7+
 
-*Ubuntu Linux* 
-```
-sudo apt-get install libffi-dev
-sudo apt-get install libffi-dev:i386  # to install 32bit version on 64bit OS
-```
+### libffi 3.1+
+environment                          | installation
+-------------------------------------|----------------------------------------------------------
+Ubuntu Linux 64-bit with 64-bit kdb+ | `sudo apt-get install libffi-dev`
+Ubuntu Linux 64-bit with 32-bit kdb+ | `sudo apt-get install libffi-dev:i386`
+macOS                                | `brew install libffi`(at time of writing is libffi 3.2.1)
+Windows                              | (no action required)
 
-*macOS*
-```
-brew install libffi     # at the time of writing is libffi 3.2.1
-```
 
-*Windows*
+### kdb+ V3.4+
 
-No steps required.
+- [download](http://kx.com/download/)
+- [install](http://code.kx.com/q/tutorials/install/)
 
-#### Library
 
-Download appropriate release archive from [releases](../../releases/latest) page(`tar.gz` for Linux/macOS or `.zip` for Windows).
-Unpack content of the archive to `QHOME`(`c:\q` on Windows or `~/q` on Linux/macOS as a default).
+## Installation
 
-```bash
-# on macOS/Linux to extract direct to $QHOME
-tar xzvf ffi_osx-v0.9.2.tar.gz -C $QHOME --strip 1
-```
+### Download
+Download the appropriate release archive from [releases](../../releases/latest) page. 
 
-On Windows, open archive and copy contents of `ffi` folder(`ffi\*`) from archive to `%QHOME%` or `c:\q`.
+### Unpack and install content of the archive 
+
+environment     | action
+----------------|---------------------------------------------------------------------------------------
+Linux and macOS | `tar xzvf ffi_osx-v0.9.2.tar.gz -C $QHOME --strip 1`
+Windows         | Open the archive and copy content of the `ffi` folder (`ffi\*`) to `%QHOME%` or `c:\q`
 
 
 ## API
 
-ffiq exposes 2 main functions in `.ffi` namespace. See `test_ffi.q` for detailed examples of usage.
+`ffi.q` exposes two main functions in `.ffi` namespace. See `test_ffi.q` for detailed examples of usage.
+
 
 ### Passing data and getting back results
 
-Throughout the library characters are used to encode types of data provided and expected as a result. These are based on `c` column for [primitive data types](http://code.kx.com/q/ref/datatypes/#primitive-datatypes) and corresponding upper case for vectors of the same type. `sz` column is useful to workout what type can hold enough data to/from C.
+Throughout the library, characters are used to encode the types of data provided and expected as a result. These are based on the `c` column of [primitive data types](http://code.kx.com/q/ref/datatypes/#primitive-datatypes) and the corresponding upper case for vectors of the same type. The `sz` column is useful to work out what type can hold enough data passing to/from C.
 
-Argument types are derived from data passed to function(in case of `cf`) or have to be explicitly specified(in case of `bind`). Number of character types provided must match number of arguments expected by C function.
-Return type is specified as single character and can be `' '`(space) which means to discard result(`void`). If not provided defaults to `int`.
+The argument types are derived from data passed to the function (in case of `cf`) or explicitly specified (in case of `bind`). The number of character types provided must match the number of arguments expected by the C function.
+The return type is specified as a single character and can be `' '` (space), which means to discard the result (i.e. `void`). If not provided, defaults to `int`.
 
-| char          | C types       |
-| ------------- | ------------- |
-| b, c, x       |  usigned int8 |
-| h             | signed int16  |
-| i             |signed int32   |
-| j             | signed int64  |
-| e             | float         |
-| f             | double        |
-| g, s          | uint8*        |
-| ' '(space)    | void (only as return type) |
-| r             | raw pointer   |
-| k             | K object      |
-| uppercase letter| pointer to the same type|
+char             | C type       
+-----------------| -------------------------|
+b, c, x          | unsigned int8
+h                | signed int16
+i                | signed int32
+j                | signed int64
+e                | float
+f                | double
+g, s             | uint8*
+`' '` (space)    | void (only as return type)
+r                | raw pointer
+k                | K object
+uppercase letter | pointer to the same type
 
-It is possible to pass a q function to C code as a callback(see qsort example below). Function must be presented as a mixed list `(func;argument_types;return_type)`, where func is a q function(type `100h`), argument_types is a char array with types function expects and char corresponding to return type of the function. Note, that as callbacks potentially have unbounded life in C code, they are not deleted after function completes.
-
-### `cf` - call function
-
-Simple function call. Intended for one-off calls. Takes 2 arguments:
-
-1. function name(symbol) or list of return type char and function name.
-2. mixed list of arguments. Types of arguments passed to function are inferred from q types and should match width of arguments C function expects. If arguments are not mixed list, append `(::)` at the end.
+It is possible to pass a q function to C code as a callback (see `qsort` example below). The function must be presented as a mixed list `(func;argument_types;return_type)`, where `func` is a q function (type `100h`), `argument_types` is a char array with the types the function expects, and `return_type` is a char corresponding to the return type of the function. Note that, as callbacks potentially have unbounded life in C code, they are not deleted after the function completes.
 
 
-### `bind` - create projection with function resolved to call with arguments
+### `cf` – call function
 
-Prepare q function and bind it to provided C function for future calls. Useful for multiple calls to C lib. Takes 3 arguments:
-1. function name. Simple symbol or list of 2 symbols specifying library name.
+Simple function call, intended for one-off calls, and taking two arguments:
+
+1. Function name (symbol) or list of return type char and function name.
+2. Mixed list of arguments. The types of arguments passed to the function are inferred from the q types and should match the width of the arguments the C function expects. (If an argument is not a mixed list, append `(::)` to it.)
+
+
+### `bind` – create projection with function resolved to call with arguments
+
+Prepares a q function and bind it to the provided C function for future calls. Useful for multiple calls to C lib. Takes three arguments:
+
+1. function name: simple symbol or list of 2 symbols specifying library name 
 2. char array of argument types
 3. char with return type
 
 
-Some additional utility functions are provided as well:
+Some utility functions are provided as well:
 
-`cif` - prepare argument and return types to be used in `call`
+function | purpose
+---------|-------------------------------------------------------------------------------------
+`cif`    | prepare argument and return types to be used in `call`
+`call`   | call function using prepared types by `cif` with arguments provided
+`errno`  | return current `errno` global on \*nix OS
+`kfn`    | bind function which returns and accepts K objects in current process. Similar to `2:`
 
-`call` - call function using prepared types by `cif` with arguments provided
+Arguments to call with should be passed as a generic list to `cf`, `call` and the function created by `bind`.
 
-`errno` - return current `errno` global on \*nix OS
-
-`kfn` - bind function which returns and accepts K objects in current process. Similar to `2:`
-
-Arguments to call with should be passed as generic list to `cf`, `call` and function created by `bind`.
-
-`cf` and `call` performs native function loading and resolution at the time of call which created significant overhead. Use `bind` to perform this steps in advance and reduce runtime overhead.
+`cf` and `call` perform native function loading and resolution at the time of the call, which creates significant overhead. Use `bind` to perform this step in advance and reduce runtime overhead.
 
 
 ## Examples
-```
+```q
 q)\l ffi.q / populates .ffi namespace
 q).ffi.cf[`strlen](`abc;::) / arguments should be passed as generic lists
 3i
@@ -120,9 +119,11 @@ q).ffi.cf[("h";`getppid)]() / specify return type, no args
 q).ffi.cf[("e";`libm.so`powf)]2 2e,(::) / explicit library
 4e
 ```
+
+
 ### BLAS 
-All arguments should be vectors(i.e. pointers to appropriate type).
-```
+All arguments should be vectors (i.e. pointers to appropriate type).
+```q
 q)x:10#2f;
 q).ffi.cf[("f";`libblas.so`ddot_)](1#count x; x;1#1;x;1#1)
 40f
@@ -130,8 +131,10 @@ q).ffi.cf[(" ";`libblas.so`daxpy_)](1#count x;1#2f; x;1#1;x;1#1)
 q)x / <- a*x+y, a=x=y=2
 6 6 6 6 6 6 6 6 6 6f
 ```
+
+
 ### Callbacks
-```
+```q
 q)cmp:{0N!x,y;(x>y)-x<y} 
 q)x:3 1 2i;
 // warning: this modifies data in-place regardless of other references.
@@ -151,7 +154,7 @@ q)x
 `a`b`c
 ```
 Register a callback on a handle
-```
+```q
 // h is handle to some other process
 r:{b:20#"\000";n:.ffi.cf[`read](x;b;20);0N!n#b;0}
 .ffi.cf[`sd1](h;(r;(),"i"))   / start handler
@@ -160,5 +163,5 @@ r:{b:20#"\000";n:.ffi.cf[`read](x;b;20);0N!n#b;0}
 
 
 - - - - - - - - -
-### Notes
+## Notes
 This version is based on original [ffiq](https://github.com/enlnt/ffiq) created by @abalkin


### PR DESCRIPTION
Subbed using conventions from code.kx.com, and my reserve supply of definite articles. 

> function name: simple symbol, or list of two symbols specifying library name

Perhaps better as 

> function name: symbol atom, or vector of two symbols

Would an example of a 2-symbol vector ‘specifying library name’ be helpful here?